### PR TITLE
Allow explicit include of non-readonly properties in ctor

### DIFF
--- a/src/AutoConstructor.Generator/AutoConstructorGenerator.cs
+++ b/src/AutoConstructor.Generator/AutoConstructorGenerator.cs
@@ -172,11 +172,16 @@ public class AutoConstructorGenerator : IIncrementalGenerator
         return symbol.GetMembers().OfType<IFieldSymbol>()
             .Where(x => x.CanBeInjected(compilation)
                 && !x.IsStatic
-                && x.IsReadOnly
+                && (x.IsReadOnly || IsPropertyWithExplicitInjection(x))
                 && !x.IsInitialized()
                 && !x.HasAttribute(Source.IgnoreAttributeFullName, compilation))
             .Select(x => GetFieldInfo(x, compilation, emitNullChecks))
             .ToList();
+
+        bool IsPropertyWithExplicitInjection(IFieldSymbol x)
+        {
+            return x.AssociatedSymbol is not null && x.HasAttribute(Source.InjectAttributeFullName, compilation);
+        }
     }
 
     private static FieldInfo GetFieldInfo(IFieldSymbol fieldSymbol, Compilation compilation, bool emitNullChecks)

--- a/tests/AutoConstructor.Tests/GeneratorTests.cs
+++ b/tests/AutoConstructor.Tests/GeneratorTests.cs
@@ -774,7 +774,7 @@ namespace Test
         public int InjectedWithDocumentation { get; }
 
         [field: AutoConstructorInject]
-        public int NotInjectedBecauseNotReadonly { get; set; }
+        public int InjectedBecauseExplicitInjection { get; set; }
 
         [field: AutoConstructorInject]
         public static int NotInjectedBecauseStatic { get; }
@@ -800,11 +800,13 @@ namespace Test
         /// </summary>
         /// <param name=""injected"">injected</param>
         /// <param name=""injectedWithDocumentation"">Some property.</param>
+        /// <param name=""injectedBecauseExplicitInjection"">injectedBecauseExplicitInjection</param>
         /// <param name=""alsoInjectedEvenWhenMissingAttribute"">alsoInjectedEvenWhenMissingAttribute</param>
-        public Test(int injected, int injectedWithDocumentation, int alsoInjectedEvenWhenMissingAttribute)
+        public Test(int injected, int injectedWithDocumentation, int injectedBecauseExplicitInjection, int alsoInjectedEvenWhenMissingAttribute)
         {
             this.Injected = injected;
             this.InjectedWithDocumentation = injectedWithDocumentation;
+            this.InjectedBecauseExplicitInjection = injectedBecauseExplicitInjection;
             this.AlsoInjectedEvenWhenMissingAttribute = alsoInjectedEvenWhenMissingAttribute;
             this.InjectedWithoutCreatingAParam = injected.ToString() ?? throw new System.ArgumentNullException(nameof(injected));
         }
@@ -857,6 +859,8 @@ namespace Test
         public readonly int _t2;
         protected readonly int _t3;
         private static readonly int _t4;
+        [AutoConstructorInject]
+        private int _t5;
     }
 }";
         const string generated = @"namespace Test


### PR DESCRIPTION
Hello, this is breaking change. If that is not OK, please consider adding a new attribute/other mechanism which would allow such behavior, I could implement it as required.
Fixed some spelling mistakes in README too.