### PR TITLE
fix/nullability-of-fields-not-extracted

### DIFF
--- a/src/AutoConstructor.Generator/AutoConstructorGenerator.cs
+++ b/src/AutoConstructor.Generator/AutoConstructorGenerator.cs
@@ -234,17 +234,18 @@ public class AutoConstructorGenerator : IIncrementalGenerator
             summaryText,
             type.IsReferenceType && type.NullableAnnotation != NullableAnnotation.Annotated && emitNullChecks,
             FieldType.Initialized);
+        
+    }
 
-        static bool IsNullable(ITypeSymbol typeSymbol)
+    private static bool IsNullable(ITypeSymbol typeSymbol)
+    {
+        bool isNullable = typeSymbol.IsReferenceType && typeSymbol.NullableAnnotation == NullableAnnotation.Annotated;
+        if (typeSymbol is INamedTypeSymbol namedSymbol)
         {
-            bool isNullable = typeSymbol.IsReferenceType && typeSymbol.NullableAnnotation == NullableAnnotation.Annotated;
-            if (typeSymbol is INamedTypeSymbol namedSymbol)
-            {
-                isNullable |= namedSymbol.TypeArguments.Any(IsNullable);
-            }
-
-            return isNullable;
+            isNullable |= namedSymbol.TypeArguments.Any(IsNullable);
         }
+
+        return isNullable;
     }
 
     private static T? GetParameterValue<T>(string parameterName, ImmutableArray<IParameterSymbol> parameters, ImmutableArray<TypedConstant> arguments)
@@ -291,7 +292,7 @@ public class AutoConstructorGenerator : IIncrementalGenerator
                     string.Empty,
                     string.Empty,
                     parameter.Type,
-                    false,
+                    IsNullable(parameter.Type),
                     null,
                     false,
                     FieldType.PassedToBase));
@@ -316,7 +317,7 @@ public class AutoConstructorGenerator : IIncrementalGenerator
                     string.Empty,
                     string.Empty,
                     parameter.FallbackType,
-                    false,
+                    IsNullable(parameter.FallbackType),
                     null,
                     false,
                     FieldType.PassedToBase));

--- a/tests/AutoConstructor.Tests/GeneratorTests.cs
+++ b/tests/AutoConstructor.Tests/GeneratorTests.cs
@@ -567,6 +567,34 @@ namespace Test
     }
 }
 ")]
+    [InlineData(@"using System.Threading.Tasks;namespace Test
+{
+    [AutoConstructor]
+    internal partial class Test : TestBase
+    {
+        
+    }
+
+    internal partial class TestBase
+    {
+        public readonly Task<Task<object?>> _t1;
+
+        public TestBase(System.Threading.Tasks.Task<System.Threading.Tasks.Task<object?>> t1)
+        {
+            this._t1 = t1 ?? throw new System.ArgumentNullException(nameof(t1));
+        }
+    }
+}", @"#nullable enable
+namespace Test
+{
+    partial class Test
+    {
+        public Test(System.Threading.Tasks.Task<System.Threading.Tasks.Task<object?>> t1) : base(t1)
+        {
+        }
+    }
+}
+")]
     public async Task Run_WithNullableReferenceType_ShouldGenerateClass(string code, string generated)
     {
         await VerifySourceGenerator.RunAsync(code, generated, nullable: true);


### PR DESCRIPTION
Fix for #58 
Do not presume nullability when creating an instance of FieldInfo.