### PR TITLE
Add support for struct types and different type kind nesting

### DIFF
--- a/src/AutoConstructor.Generator/Analyzers/TypeWithWrongConstructorAccessibilityAnalyzer.cs
+++ b/src/AutoConstructor.Generator/Analyzers/TypeWithWrongConstructorAccessibilityAnalyzer.cs
@@ -7,9 +7,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace AutoConstructor.Generator.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class ClassWithWrongConstructorAccessibilityAnalyzer : DiagnosticAnalyzer
+public sealed class TypeWithWrongConstructorAccessibilityAnalyzer : DiagnosticAnalyzer
 {
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.ClassWithWrongConstructorAccessibilityRule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.TypeWithWrongConstructorAccessibilityRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -25,13 +25,13 @@ public sealed class ClassWithWrongConstructorAccessibilityAnalyzer : DiagnosticA
     {
         var symbol = (INamedTypeSymbol)context.Symbol;
 
-        if (symbol.DeclaringSyntaxReferences[0].GetSyntax() is ClassDeclarationSyntax classDeclarationSyntax
+        if (symbol.DeclaringSyntaxReferences[0].GetSyntax() is TypeDeclarationSyntax typeDeclarationSyntax
             && symbol.GetAttribute(Source.AttributeFullName) is AttributeData attribute
             && attribute.AttributeConstructor?.Parameters.Length > 0
             && attribute.GetParameterValue<string>("accessibility") is string { Length: > 0 } accessibilityValue
             && !AutoConstructorGenerator.ConstuctorAccessibilities.Contains(accessibilityValue))
         {
-            var diagnostic = Diagnostic.Create(DiagnosticDescriptors.ClassWithWrongConstructorAccessibilityRule, classDeclarationSyntax.Identifier.GetLocation());
+            var diagnostic = Diagnostic.Create(DiagnosticDescriptors.TypeWithWrongConstructorAccessibilityRule, typeDeclarationSyntax.Identifier.GetLocation());
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/src/AutoConstructor.Generator/Analyzers/TypeWithoutFieldsToInjectAnalyzer.cs
+++ b/src/AutoConstructor.Generator/Analyzers/TypeWithoutFieldsToInjectAnalyzer.cs
@@ -6,9 +6,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace AutoConstructor.Generator.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class ClassWithoutFieldsToInjectAnalyzer : DiagnosticAnalyzer
+public sealed class TypeWithoutFieldsToInjectAnalyzer : DiagnosticAnalyzer
 {
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.ClassWithoutFieldsToInjectRule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.TypeWithoutFieldsToInjectRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -33,7 +33,7 @@ public sealed class ClassWithoutFieldsToInjectAnalyzer : DiagnosticAnalyzer
                 if (propertyTypeIdentifier is not null)
                 {
                     var location = Location.Create(propertyTypeIdentifier.SyntaxTree, propertyTypeIdentifier.Span);
-                    var diagnostic = Diagnostic.Create(DiagnosticDescriptors.ClassWithoutFieldsToInjectRule, location);
+                    var diagnostic = Diagnostic.Create(DiagnosticDescriptors.TypeWithoutFieldsToInjectRule, location);
                     context.ReportDiagnostic(diagnostic);
                 }
             }

--- a/src/AutoConstructor.Generator/Analyzers/TypeWithoutPartialAnalyzer.cs
+++ b/src/AutoConstructor.Generator/Analyzers/TypeWithoutPartialAnalyzer.cs
@@ -8,9 +8,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace AutoConstructor.Generator.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class ClassWithoutPartialAnalyzer : DiagnosticAnalyzer
+public sealed class TypeWithoutPartialAnalyzer : DiagnosticAnalyzer
 {
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.ClassWithoutPartialRule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.TypeWithoutPartialRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -26,11 +26,11 @@ public sealed class ClassWithoutPartialAnalyzer : DiagnosticAnalyzer
     {
         var symbol = (INamedTypeSymbol)context.Symbol;
 
-        if (symbol.DeclaringSyntaxReferences[0].GetSyntax() is ClassDeclarationSyntax classDeclarationSyntax
+        if (symbol.DeclaringSyntaxReferences[0].GetSyntax() is TypeDeclarationSyntax typeDeclarationSyntax
             && symbol.HasAttribute(Source.AttributeFullName)
-            && !classDeclarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword))
+            && !typeDeclarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword))
         {
-            var diagnostic = Diagnostic.Create(DiagnosticDescriptors.ClassWithoutPartialRule, classDeclarationSyntax.Identifier.GetLocation());
+            var diagnostic = Diagnostic.Create(DiagnosticDescriptors.TypeWithoutPartialRule, typeDeclarationSyntax.Identifier.GetLocation());
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/src/AutoConstructor.Generator/AutoConstructorGenerator.cs
+++ b/src/AutoConstructor.Generator/AutoConstructorGenerator.cs
@@ -59,9 +59,8 @@ public sealed class AutoConstructorGenerator : IIncrementalGenerator
 
     private static bool IsSyntaxTargetForGeneration(SyntaxNode node)
     {
-        return
-            (node is ClassDeclarationSyntax { AttributeLists.Count: > 0 } classDeclarationSyntax && classDeclarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword)) ||
-            (node is StructDeclarationSyntax { AttributeLists.Count: > 0 } structDeclarationSyntax && structDeclarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword));
+        // We don't need to filter for class/struct here, as FAWMN is already doing that extra work for us
+        return node is TypeDeclarationSyntax { AttributeLists.Count: > 0 } typeDeclarationSyntax && typeDeclarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword);
     }
 
     private static Options ParseOptions(AnalyzerConfigOptions analyzerOptions)

--- a/src/AutoConstructor.Generator/CodeFixes/ClassWithoutPartialCodeFixProvider.cs
+++ b/src/AutoConstructor.Generator/CodeFixes/ClassWithoutPartialCodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace AutoConstructor.Generator.CodeFixes;
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ClassWithoutPartialCodeFixProvider)), Shared]
 public sealed class ClassWithoutPartialCodeFixProvider : CodeFixProvider
 {
-    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticDescriptors.ClassWithoutPartialDiagnosticId);
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticDescriptors.TypeWithoutPartialDiagnosticId);
 
     public override FixAllProvider GetFixAllProvider()
     {

--- a/src/AutoConstructor.Generator/CodeFixes/RemoveAttributeCodeFixProvider.cs
+++ b/src/AutoConstructor.Generator/CodeFixes/RemoveAttributeCodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace AutoConstructor.Generator.CodeFixes;
 public sealed class RemoveAttributeCodeFixProvider : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
-        DiagnosticDescriptors.ClassWithoutFieldsToInjectDiagnosticId,
+        DiagnosticDescriptors.TypeWithoutFieldsToInjectDiagnosticId,
         DiagnosticDescriptors.IgnoreAttributeOnNonProcessedFieldDiagnosticId,
         DiagnosticDescriptors.InjectAttributeOnIgnoredFieldDiagnosticId,
         DiagnosticDescriptors.IgnoreOrInjectAttributeOnClassWithoutAttributeDiagnosticId,

--- a/src/AutoConstructor.Generator/DiagnosticDescriptors.cs
+++ b/src/AutoConstructor.Generator/DiagnosticDescriptors.cs
@@ -4,9 +4,9 @@ namespace AutoConstructor.Generator;
 
 public static class DiagnosticDescriptors
 {
-    public const string ClassWithoutPartialDiagnosticId = "ACONS01";
+    public const string TypeWithoutPartialDiagnosticId = "ACONS01";
 
-    public const string ClassWithoutFieldsToInjectDiagnosticId = "ACONS02";
+    public const string TypeWithoutFieldsToInjectDiagnosticId = "ACONS02";
 
     public const string IgnoreAttributeOnNonProcessedFieldDiagnosticId = "ACONS03";
 
@@ -16,7 +16,7 @@ public static class DiagnosticDescriptors
 
     public const string MistmatchTypesDiagnosticId = "ACONS06";
 
-    public const string ClassWithWrongConstructorAccessibilityDiagnosticId = "ACONS07";
+    public const string TypeWithWrongConstructorAccessibilityDiagnosticId = "ACONS07";
 
     public const string MultipleInitializerMethodsDiagnosticId = "ACONS08";
 
@@ -24,26 +24,26 @@ public static class DiagnosticDescriptors
 
     public const string InitializerMethodMustBeParameterlessDiagnosticId = "ACONS10";
 
-    public static readonly DiagnosticDescriptor ClassWithoutPartialRule = new(
-        ClassWithoutPartialDiagnosticId,
+    public static readonly DiagnosticDescriptor TypeWithoutPartialRule = new(
+        TypeWithoutPartialDiagnosticId,
         "Couldn't generate constructor",
         $"Type decorated with {Source.AttributeFullName} must be also declared partial",
         "Usage",
         DiagnosticSeverity.Warning,
         true,
         null,
-        $"https://github.com/k94ll13nn3/AutoConstructor#{ClassWithoutPartialDiagnosticId}",
+        $"https://github.com/k94ll13nn3/AutoConstructor#{TypeWithoutPartialDiagnosticId}",
         WellKnownDiagnosticTags.Build);
 
-    public static readonly DiagnosticDescriptor ClassWithoutFieldsToInjectRule = new(
-        ClassWithoutFieldsToInjectDiagnosticId,
+    public static readonly DiagnosticDescriptor TypeWithoutFieldsToInjectRule = new(
+        TypeWithoutFieldsToInjectDiagnosticId,
         $"Remove {Source.AttributeFullName}",
         $"{Source.AttributeFullName} has no effect on a class without fields to inject",
         "Usage",
         DiagnosticSeverity.Warning,
         true,
         null,
-        $"https://github.com/k94ll13nn3/AutoConstructor#{ClassWithoutFieldsToInjectDiagnosticId}",
+        $"https://github.com/k94ll13nn3/AutoConstructor#{TypeWithoutFieldsToInjectDiagnosticId}",
         WellKnownDiagnosticTags.Unnecessary);
 
     public static readonly DiagnosticDescriptor IgnoreAttributeOnNonProcessedFieldRule = new(
@@ -90,15 +90,15 @@ public static class DiagnosticDescriptors
         $"https://github.com/k94ll13nn3/AutoConstructor#{MistmatchTypesDiagnosticId}",
         WellKnownDiagnosticTags.Build);
 
-    public static readonly DiagnosticDescriptor ClassWithWrongConstructorAccessibilityRule = new(
-        ClassWithWrongConstructorAccessibilityDiagnosticId,
+    public static readonly DiagnosticDescriptor TypeWithWrongConstructorAccessibilityRule = new(
+        TypeWithWrongConstructorAccessibilityDiagnosticId,
         "Wrong constuctor accessibility",
         "Unknown constuctor accessibility, allowed values are public, private, protected, internal, protected internal or private protected",
         "Usage",
         DiagnosticSeverity.Warning,
         true,
         null,
-        $"https://github.com/k94ll13nn3/AutoConstructor#{ClassWithWrongConstructorAccessibilityDiagnosticId}",
+        $"https://github.com/k94ll13nn3/AutoConstructor#{TypeWithWrongConstructorAccessibilityDiagnosticId}",
         WellKnownDiagnosticTags.Build);
 
     public static readonly DiagnosticDescriptor MultipleInitializerMethodsRule = new(

--- a/src/AutoConstructor.Generator/Extensions/IndentedTextWriterExtension.cs
+++ b/src/AutoConstructor.Generator/Extensions/IndentedTextWriterExtension.cs
@@ -1,5 +1,8 @@
 using AutoConstructor.Generator.Core;
 using AutoConstructor.Generator.Models;
+using Microsoft.CodeAnalysis;
+
+#pragma warning disable IDE0072
 
 namespace AutoConstructor.Generator.Extensions;
 
@@ -12,7 +15,15 @@ internal static class IndentedTextWriterExtension
             writer.Write("static ");
         }
 
-        writer.Write($"partial class {symbol.Name}");
+        writer.Write("partial ");
+        writer.Write(symbol.Kind switch
+        {
+            TypeKind.Struct => "struct",
+            TypeKind.Interface => "interface",
+            _ => "class"
+        });
+        writer.Write(" ");
+        writer.Write(symbol.Name);
 
         if (!symbol.TypeParameters.IsEmpty)
         {

--- a/src/AutoConstructor.Generator/Models/MainNamedTypeSymbolInfo.cs
+++ b/src/AutoConstructor.Generator/Models/MainNamedTypeSymbolInfo.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 namespace AutoConstructor.Generator.Models;
 
 internal sealed record MainNamedTypeSymbolInfo(
+    TypeKind Kind,
     string Name,
     bool IsStatic,
     EquatableArray<string> TypeParameters,
@@ -15,7 +16,7 @@ internal sealed record MainNamedTypeSymbolInfo(
     string Filename,
     string Accessibility,
     InitializerMethodInfo? InitializerMethod)
-    : NamedTypeSymbolInfo(Name, IsStatic, TypeParameters)
+    : NamedTypeSymbolInfo(Kind, Name, IsStatic, TypeParameters)
 {
     public MainNamedTypeSymbolInfo(
         INamedTypeSymbol namedTypeSymbol,
@@ -24,6 +25,7 @@ internal sealed record MainNamedTypeSymbolInfo(
         string accessibility,
         InitializerMethodInfo? initializerMethod)
         : this(
+            namedTypeSymbol.TypeKind,
             namedTypeSymbol.Name,
             namedTypeSymbol.IsStatic,
             namedTypeSymbol.TypeParameters.Select(t => t.Name).ToImmutableArray(),

--- a/src/AutoConstructor.Generator/Models/NamedTypeSymbolInfo.cs
+++ b/src/AutoConstructor.Generator/Models/NamedTypeSymbolInfo.cs
@@ -4,10 +4,10 @@ using Microsoft.CodeAnalysis;
 
 namespace AutoConstructor.Generator.Models;
 
-internal record NamedTypeSymbolInfo(string Name, bool IsStatic, EquatableArray<string> TypeParameters)
+internal record NamedTypeSymbolInfo(TypeKind Kind, string Name, bool IsStatic, EquatableArray<string> TypeParameters)
 {
     public NamedTypeSymbolInfo(INamedTypeSymbol namedTypeSymbol)
-        : this(namedTypeSymbol.Name, namedTypeSymbol.IsStatic, namedTypeSymbol.TypeParameters.Select(t => t.Name).ToImmutableArray())
+        : this(namedTypeSymbol.TypeKind, namedTypeSymbol.Name, namedTypeSymbol.IsStatic, namedTypeSymbol.TypeParameters.Select(t => t.Name).ToImmutableArray())
     {
     }
 }

--- a/src/AutoConstructor.Generator/Source.cs
+++ b/src/AutoConstructor.Generator/Source.cs
@@ -13,7 +13,7 @@ public static class Source
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[System.AttributeUsage(System.AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+[System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
 internal sealed class {AttributeFullName} : System.Attribute
 {{
     public {AttributeFullName}(string accessibility = null)

--- a/tests/AutoConstructor.Tests/Analyzers/TypeWithWrongConstructorAccessibilityTests.cs
+++ b/tests/AutoConstructor.Tests/Analyzers/TypeWithWrongConstructorAccessibilityTests.cs
@@ -2,11 +2,11 @@ using AutoConstructor.Generator;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyClassWithWrongConstructorAccessibility = AutoConstructor.Tests.Verifiers.CSharpAnalyzerVerifier<
-    AutoConstructor.Generator.Analyzers.ClassWithWrongConstructorAccessibilityAnalyzer>;
+    AutoConstructor.Generator.Analyzers.TypeWithWrongConstructorAccessibilityAnalyzer>;
 
 namespace AutoConstructor.Tests.Analyzers;
 
-public class ClassWithWrongConstructorAccessibilityTests
+public class TypeWithWrongConstructorAccessibilityTests
 {
     [Fact]
     public async Task Analyzer_ClassWithWrongConstructorAccessibility_ShouldReportDiagnostic()
@@ -22,7 +22,7 @@ namespace Test
 }";
 
         DiagnosticResult[] expected = [
-                VerifyClassWithWrongConstructorAccessibility.Diagnostic(DiagnosticDescriptors.ClassWithWrongConstructorAccessibilityDiagnosticId).WithLocation(0),
+                VerifyClassWithWrongConstructorAccessibility.Diagnostic(DiagnosticDescriptors.TypeWithWrongConstructorAccessibilityDiagnosticId).WithLocation(0),
         ];
         await VerifyClassWithWrongConstructorAccessibility.VerifyAnalyzerAsync(test, expected);
     }

--- a/tests/AutoConstructor.Tests/Analyzers/TypeWithoutFieldsToInjectTests.cs
+++ b/tests/AutoConstructor.Tests/Analyzers/TypeWithoutFieldsToInjectTests.cs
@@ -2,12 +2,12 @@ using AutoConstructor.Generator;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyClassWithoutFieldsToInject = AutoConstructor.Tests.Verifiers.CSharpCodeFixVerifier<
-    AutoConstructor.Generator.Analyzers.ClassWithoutFieldsToInjectAnalyzer,
+    AutoConstructor.Generator.Analyzers.TypeWithoutFieldsToInjectAnalyzer,
     AutoConstructor.Generator.CodeFixes.RemoveAttributeCodeFixProvider>;
 
 namespace AutoConstructor.Tests.Analyzers;
 
-public class ClassWithoutFieldsToInjectTests
+public class TypeWithoutFieldsToInjectTests
 {
     [Fact]
     public async Task Analyzer_ClassWithoutFieldsToInject_ShouldReportDiagnostic()
@@ -22,7 +22,7 @@ namespace Test
 }";
 
         DiagnosticResult[] expected = [
-                VerifyClassWithoutFieldsToInject.Diagnostic(DiagnosticDescriptors.ClassWithoutFieldsToInjectDiagnosticId).WithLocation(0),
+                VerifyClassWithoutFieldsToInject.Diagnostic(DiagnosticDescriptors.TypeWithoutFieldsToInjectDiagnosticId).WithLocation(0),
         ];
         await VerifyClassWithoutFieldsToInject.VerifyAnalyzerAsync(test, expected);
     }
@@ -158,7 +158,7 @@ namespace Test
     public async Task Analyzer_ClassWithoutFieldsToInject_ShouldFixCode(string test, string fixtest)
     {
         DiagnosticResult[] expected = [
-                VerifyClassWithoutFieldsToInject.Diagnostic(DiagnosticDescriptors.ClassWithoutFieldsToInjectDiagnosticId).WithLocation(0),
+                VerifyClassWithoutFieldsToInject.Diagnostic(DiagnosticDescriptors.TypeWithoutFieldsToInjectDiagnosticId).WithLocation(0),
         ];
         await VerifyClassWithoutFieldsToInject.VerifyCodeFixAsync(test, expected, fixtest);
     }

--- a/tests/AutoConstructor.Tests/Analyzers/TypeWithoutPartialTests.cs
+++ b/tests/AutoConstructor.Tests/Analyzers/TypeWithoutPartialTests.cs
@@ -2,12 +2,12 @@ using AutoConstructor.Generator;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyClassWithoutPartial = AutoConstructor.Tests.Verifiers.CSharpCodeFixVerifier<
-    AutoConstructor.Generator.Analyzers.ClassWithoutPartialAnalyzer,
+    AutoConstructor.Generator.Analyzers.TypeWithoutPartialAnalyzer,
     AutoConstructor.Generator.CodeFixes.ClassWithoutPartialCodeFixProvider>;
 
 namespace AutoConstructor.Tests.Analyzers;
 
-public class ClassWithoutPartialTests
+public class TypeWithoutPartialTests
 {
     [Fact]
     public async Task Analyzer_ClassWithoutPartial_ShouldReportDiagnostic()
@@ -23,7 +23,7 @@ namespace Test
 }";
 
         DiagnosticResult[] expected = [
-                VerifyClassWithoutPartial.Diagnostic(DiagnosticDescriptors.ClassWithoutPartialDiagnosticId).WithLocation(0),
+                VerifyClassWithoutPartial.Diagnostic(DiagnosticDescriptors.TypeWithoutPartialDiagnosticId).WithLocation(0),
         ];
         await VerifyClassWithoutPartial.VerifyAnalyzerAsync(test, expected);
     }
@@ -52,7 +52,7 @@ namespace Test
 }";
 
         DiagnosticResult[] expected = [
-                VerifyClassWithoutPartial.Diagnostic(DiagnosticDescriptors.ClassWithoutPartialDiagnosticId).WithLocation(0),
+                VerifyClassWithoutPartial.Diagnostic(DiagnosticDescriptors.TypeWithoutPartialDiagnosticId).WithLocation(0),
         ];
         await VerifyClassWithoutPartial.VerifyCodeFixAsync(test, expected, fixtest);
     }


### PR DESCRIPTION
Hey there! I'm looking into using AutoConstructor for my unit tests in https://github.com/Sergio0694/ComputeSharp, but I realized I was missing a couple features for this to work. Specifically, support for struct types and nested types of different kinds. It seems like the support for all this was almost there already, so this PR just includes a few tweaks to get all that to work 🙂

The changes here are these two things:
- Making `[AutoConstructor]` also support struct types, and updating the generator
- Supporting nested type hierarchies of different type kinds (ie. mixed class/struct/interface)

Also added a bunch of unit tests to cover the new scenarios.